### PR TITLE
meson: add libcap dep if sys/capability.h is not found

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -290,12 +290,6 @@ conf.set('GPERF_LEN_TYPE', gperf_len_type,
 
 ############################################################
 
-if not cc.has_header('sys/capability.h')
-        libcap = dependency('libcap')
-        if not libcap.found()
-                error('POSIX caps headers not found')
-        endif
-endif
 foreach header : ['crypt.h',
                   'linux/memfd.h',
                   'sys/auxv.h',

--- a/meson.build
+++ b/meson.build
@@ -291,7 +291,10 @@ conf.set('GPERF_LEN_TYPE', gperf_len_type,
 ############################################################
 
 if not cc.has_header('sys/capability.h')
-        error('POSIX caps headers not found')
+        libcap = dependency('libcap')
+        if not libcap.found()
+                error('POSIX caps headers not found')
+        endif
 endif
 foreach header : ['crypt.h',
                   'linux/memfd.h',


### PR DESCRIPTION
On alpine systems `sys/capability.h` is in the `libcap` package, this patch adds the library as a dependency if the file is not found.