### PR TITLE
make dbus system bus default address configurable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -212,6 +212,9 @@ if not meson.is_cross_build()
 endif
 conf.set_quoted('NOBODY_USER_NAME', nobody_user)
 
+system_bus_address = get_option('system-bus-address')
+conf.set_quoted('DEFAULT_SYSTEM_BUS_ADDRESS', system_bus_address)
+
 conf.set_quoted('GETTEXT_PACKAGE', meson.project_name())
 
 enable_debug_hashmap = false

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,5 +8,9 @@ option('nobody-user', type : 'string',
        description : 'The name of the nobody user (the one with UID 65534)',
        value : 'nobody')
 
+option('system-bus-address', type : 'string',
+       description : 'The address of the sytem bus (defined at dbus compilation)',
+       value : 'unix:path=/run/dbus/system_bus_socket')
+
 option('audit', type : 'combo', choices : ['auto', 'true', 'false'],
        description : 'libaudit support')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,7 +10,7 @@ option('nobody-user', type : 'string',
 
 option('system-bus-address', type : 'string',
        description : 'The address of the sytem bus (defined at dbus compilation)',
-       value : 'unix:path=/run/dbus/system_bus_socket')
+       value : 'unix:path=/var/run/dbus/system_bus_socket')
 
 option('audit', type : 'combo', choices : ['auto', 'true', 'false'],
        description : 'libaudit support')

--- a/src/basic/def.h
+++ b/src/basic/def.h
@@ -3,9 +3,6 @@
 
 #define DEFAULT_TIMEOUT_USEC (90*USEC_PER_SEC)
 
-/* Note that we use the new /run prefix here (instead of /var/run) since we require them to be aliases and that way we
- * become independent of /var being mounted */
-#define DEFAULT_SYSTEM_BUS_ADDRESS "unix:path=/run/dbus/system_bus_socket"
 #define DEFAULT_USER_BUS_ADDRESS_FMT "unix:path=%s/bus"
 
 #define LONG_LINE_MAX (1U*1024U*1024U)


### PR DESCRIPTION
This tries to solve #30 with making the system bus default address configurable by the user, while defaulting to what has been hardcoded before. 

Many thanks to @vilhalmer for helping out in that issue :-) 