### PR TITLE
Meson: Search sh in PATH and fallback to /bin/sh

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -155,6 +155,7 @@ endforeach
 
 #####################################################################
 
+sh = find_program('sh', dirs : '/bin')
 sed = find_program('sed')
 awk = find_program('awk')
 
@@ -168,7 +169,7 @@ const char * in_word_set(const char *, @0@);
 @1@
 '''
 gperf_snippet_format = 'echo foo,bar | @0@ -L ANSI-C'
-gperf_snippet = run_command('sh', '-c', gperf_snippet_format.format(gperf.path()))
+gperf_snippet = run_command(sh, '-c', gperf_snippet_format.format(gperf.path()))
 gperf_test = gperf_test_format.format('size_t', gperf_snippet.stdout())
 if cc.compiles(gperf_test)
         gperf_len_type = 'size_t'


### PR DESCRIPTION
This is a trivial patch that add a fallback to `/bin/sh` if `sh` is not found in PATH. This may happen in constrained environments (build systems, containers, etc.).
The argument `dirs` is available in Meson since 0.53, but the minimum required is 0.54 for basu.
Thank you!