### PR TITLE
freebsd: Do not use cr_pid from LOCAL_PEERCRED

### DIFF
--- a/src/basic/socket-util.c
+++ b/src/basic/socket-util.c
@@ -41,11 +41,7 @@ int getpeercred(int fd, struct ucred *ucred) {
         }
 
         struct ucred u = {
-#if __FreeBSD_version >= 1300030 || (__FreeBSD_version >= 1202506 && __FreeBSD_version < 1300000)
-                .pid = cred.cr_pid,
-#else
                 .pid = -1,
-#endif
                 .uid = cred.cr_uid,
                 .gid = cred.cr_ngroups > 0 ? cred.cr_groups[0] : (gid_t)-1,
         };


### PR DESCRIPTION
LOCAL_PEERCRED is used as substitute for SO_PEERCRED on FreeBSD. One of
the fields needed from there is the PID of the peer process. However,
while SO_PEERCRED returns the PID at the time of connect(2),
LOCAL_PEERCRED returns the PID at the time of listen(2). If the dbus
daemon fork(2)'d after listen(2) to daemonize, then the PID returned
will no longer exist, which breaks basu.

Remove the use of cr_pid for now, as it cannot be used.

/cc @jbeich